### PR TITLE
プロトタイプ削除機能

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,5 @@
 class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
-  
 
   private
 

--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -1,7 +1,7 @@
 class PrototypesController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
   before_action :set_prototype, only: [:edit, :update]
-  
+
   def index
     @prototype = Prototype.all
     @prototypes = Prototype.all
@@ -25,11 +25,11 @@ class PrototypesController < ApplicationController
   def show
     @prototype = Prototype.find(params[:id])
   end
-  
+
   def edit
-    if current_user != @prototype.user
-      redirect_to root_path
-    end
+    return unless current_user != @prototype.user
+
+    redirect_to root_path
   end
 
   def update
@@ -46,7 +46,7 @@ class PrototypesController < ApplicationController
     @prototype.destroy
     redirect_to root_path
   end
-  
+
   private
 
   def prototype_params

--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -28,7 +28,6 @@ class PrototypesController < ApplicationController
 
   def edit
     return unless current_user != @prototype.user
-
     redirect_to root_path
   end
 
@@ -45,6 +44,7 @@ class PrototypesController < ApplicationController
     @prototype = Prototype.find(params[:id])
     @prototype.destroy
     redirect_to root_path
+    return unless current_user != @prototype.user
   end
 
   private

--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -41,6 +41,12 @@ class PrototypesController < ApplicationController
     end
   end
 
+  def destroy
+    @prototype = Prototype.find(params[:id])
+    @prototype.destroy
+    redirect_to root_path
+  end
+  
   private
 
   def prototype_params

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,5 +4,4 @@ class UsersController < ApplicationController
 
   def show
   end
-  
 end

--- a/app/views/prototypes/show.html.erb
+++ b/app/views/prototypes/show.html.erb
@@ -9,7 +9,7 @@
         <div class="prototype__manage">
           <% if user_signed_in? && current_user == @prototype.user %>
             <%= link_to "編集する", edit_prototype_path(@prototype.id), class: :prototype__btn %>
-            <%= link_to "削除する", root_path, class: :prototype__btn %>
+            <%= link_to "削除する", prototype_path(@prototype.id), data: { turbo_method: :delete }, class: :prototype__btn %>
           <% end %>
         </div>
       <%# // プロトタイプの投稿者とログインしているユーザーが同じであれば上記を表示する %>


### PR DESCRIPTION
# What
プロトタイプ削除機能

# Why
プロトタイプの削除機能を実装するため


ログイン状態の投稿者のみ、詳細ページの削除ボタンを押すと、投稿したプロトタイプを削除できる動画
https://i.gyazo.com/760002d4901bb37047bfc4e91b63eddc.mp4